### PR TITLE
Fix Patch 6 regex, add binary detection, fix workflow permissions

### DIFF
--- a/.github/workflows/check-patches.yml
+++ b/.github/workflows/check-patches.yml
@@ -5,6 +5,10 @@ on:
     - cron: "0 8 * * *"
   workflow_dispatch:
 
+permissions:
+  contents: read
+  issues: write
+
 jobs:
   check-patches:
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ Restores your original Claude Code binary and removes the cache.
 
 ## What it patches
 
-6 locations in Claude Code's `cli.js`, all using content-based pattern matching:
+6 locations in Claude Code's `cli.js`. Patches 1–5 use literal string matching; Patch 6 uses regex to handle obfuscated function names that change between builds:
 
 | #   | What                    | Why                                                                   |
 | --- | ----------------------- | --------------------------------------------------------------------- |

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -247,18 +247,46 @@ def main():
     )
 
     # --- PATCH 6: Alias resolver fallback ---
-    # The built-in alias lists (e36, vF9) are built from process.env at module init,
-    # before settings.json env vars are loaded. Custom aliases miss the zc() guard
+    # The built-in alias lists are built from process.env at module init,
+    # before settings.json env vars are loaded. Custom aliases miss the guard
     # and skip the resolver switch entirely. This adds a fallback env var lookup
     # AFTER the switch block so custom aliases always resolve correctly.
-    apply_patch(
-        "Patch 6: Alias resolver fallback",
-        'if(QA()==="firstParty"&&e_z(z)&&IS1())',
-        'var _fev="ANTHROPIC_DEFAULT_"+z.toUpperCase().replace(/-/g,"_")+"_MODEL";'
-        'if(process.env[_fev])return process.env[_fev]/*ccpatch:fallback-resolver*/;'
-        'if(QA()==="firstParty"&&e_z(z)&&IS1())',
-        skip_marker='/*ccpatch:fallback-resolver*/',
-    )
+    # Uses regex because the obfuscated function names change every build.
+    if '/*ccpatch:fallback-resolver*/' in content:
+        print("  SKIP Patch 6: Alias resolver fallback (already patched)")
+    else:
+        p6_match = re.search(
+            r'(default:\})(if\(\w+\(\)==="firstParty"&&\w+\(\w+\)&&\w+\(\)\))',
+            content
+        )
+        if not p6_match:
+            print("  FAIL Patch 6: Alias resolver fallback — pattern not found")
+            fail_count += 1
+        elif content.count(p6_match.group(0)) > 1:
+            print(f"  FAIL Patch 6: Alias resolver fallback — pattern found {content.count(p6_match.group(0))} times (expected 1)")
+            fail_count += 1
+        else:
+            p6_original = p6_match.group(0)
+            p6_firstparty = p6_match.group(2)
+            p6_replacement = (
+                p6_match.group(1)
+                + 'var _fev="ANTHROPIC_DEFAULT_"+z.toUpperCase().replace(/-/g,"_")+"_MODEL";'
+                + 'if(process.env[_fev])return process.env[_fev]/*ccpatch:fallback-resolver*/;'
+                + p6_firstparty
+            )
+            old_len = len(content)
+            content = content.replace(p6_original, p6_replacement, 1)
+            new_len = len(content)
+            expected_diff = len(p6_replacement) - len(p6_original)
+            if new_len - old_len != expected_diff:
+                print(f"  FAIL Patch 6: Alias resolver fallback — size change mismatch")
+                fail_count += 1
+            elif p6_replacement not in content:
+                print(f"  FAIL Patch 6: Alias resolver fallback — replacement text not found after patching")
+                fail_count += 1
+            else:
+                print(f"  OK   Patch 6: Alias resolver fallback")
+                patch_count += 1
 
     print()
     print(f"=== Results ===")
@@ -326,6 +354,28 @@ if ! python3 "$CACHE_DIR/patch.py" "$CACHE_DIR/cli.js" "$CACHE_DIR/cli.js"; then
 fi
 
 echo "$VERSION" > "$CACHE_DIR/.version"
+
+# --- Detect existing installation ---
+echo ""
+CLAUDE_PATH=$(which claude 2>/dev/null || echo "")
+if [[ -n "$CLAUDE_PATH" ]]; then
+    if grep -q 'claude-alias-patch' "$CLAUDE_PATH" 2>/dev/null; then
+        echo "  Detected: existing wrapper (updating)"
+    elif [[ -L "$CLAUDE_PATH" ]]; then
+        REAL=$(readlink -f "$CLAUDE_PATH")
+        if file "$REAL" 2>/dev/null | grep -qE 'ELF|Mach-O'; then
+            echo "  Detected: native binary (via symlink → $REAL)"
+            echo "  The binary will be backed up. The patched version runs from npm via node."
+        fi
+    elif file "$CLAUDE_PATH" 2>/dev/null | grep -qE 'ELF|Mach-O'; then
+        echo "  Detected: native binary ($CLAUDE_PATH)"
+        echo "  The binary will be backed up. The patched version runs from npm via node."
+    else
+        echo "  Detected: existing npm installation"
+    fi
+else
+    echo "  No existing Claude Code installation found"
+fi
 
 # --- Install wrapper ---
 echo ""

--- a/scripts/uninstall.sh
+++ b/scripts/uninstall.sh
@@ -16,7 +16,11 @@ echo ""
 if [[ -e "$BACKUP_PATH" ]]; then
     rm -f "$BIN_PATH" 2>/dev/null || true
     mv "$BACKUP_PATH" "$BIN_PATH"
-    echo "  Restored original: $BIN_PATH"
+    if [[ -L "$BIN_PATH" ]]; then
+        echo "  Restored original symlink: $BIN_PATH → $(readlink -f "$BIN_PATH")"
+    else
+        echo "  Restored original: $BIN_PATH"
+    fi
 elif [[ -e "$BIN_PATH" ]] && grep -q 'claude-alias-patch' "$BIN_PATH" 2>/dev/null; then
     rm "$BIN_PATH"
     echo "  Removed wrapper: $BIN_PATH"


### PR DESCRIPTION
## Summary

- **Patch 6 regex**: Rewrote from hardcoded function names to regex matching — handles obfuscated names that change between builds (fixes daily CI failure on v2.1.77+)
- **Binary detection**: Installer now detects native binary installs (direct or via symlink) and informs the user their binary will be backed up
- **Uninstall messaging**: Distinguishes symlinks from regular files when restoring the original `claude` binary
- **Workflow permissions**: Added `contents: read` + `issues: write` so the daily check can auto-create issues on patch failure

## Test plan

- [ ] Run `install.sh` on a machine with native binary symlink — verify detection output
- [ ] Verify backup at `~/.local/bin/claude.bak` preserves symlink
- [ ] Verify `claude --version` runs the patched wrapper
- [ ] Run `uninstall.sh` — verify symlink is restored with correct messaging
- [ ] All 6 patches pass against latest npm release
- [ ] Trigger `check-patches` workflow manually — verify it succeeds and has issue-creation permissions