### PR TITLE
ci: add patch check workflow for PRs

### DIFF
--- a/.github/workflows/check-patches-pr.yml
+++ b/.github/workflows/check-patches-pr.yml
@@ -1,0 +1,37 @@
+name: Check Patches (PR)
+
+on:
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  check-patches:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4
+
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        with:
+          node-version: "20"
+
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
+        with:
+          python-version: "3.x"
+
+      - name: Fetch latest Claude Code
+        run: |
+          npm pack @anthropic-ai/claude-code@latest
+          mkdir -p test-pkg
+          tar -xzf anthropic-ai-claude-code-*.tgz -C test-pkg --strip-components=1
+          head -5 test-pkg/cli.js
+
+      - name: Extract patcher from install.sh
+        run: |
+          sed -n '/^cat > .*patch\.py.*<< .PATCHER_EOF/,/^PATCHER_EOF/p' scripts/install.sh | tail -n +2 | head -n -1 > patch.py
+          head -5 patch.py
+
+      - name: Run patcher
+        run: python3 patch.py test-pkg/cli.js test-pkg/cli-patched.js


### PR DESCRIPTION
## Summary

- Adds a GitHub Actions workflow that runs the patch check on PRs to `main`
- Same steps as the daily scheduled check (fetch latest Claude Code, extract patcher, run it) — without the auto-issue creation
- Required status check already configured in the repo ruleset