### PR TITLE
fix: patch 6 regex to handle $ in obfuscated identifiers

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -256,7 +256,7 @@ def main():
         print("  SKIP Patch 6: Alias resolver fallback (already patched)")
     else:
         p6_match = re.search(
-            r'(default:\})(if\(\w+\(\)==="firstParty"&&\w+\(\w+\)&&\w+\(\)\))',
+            r'(default:\})(if\([\w$]+\(\)==="firstParty"&&[\w$]+\([\w$]+\)&&[\w$]+\(\)\))',
             content
         )
         if not p6_match:


### PR DESCRIPTION
## Summary

- Patch 6 (alias resolver fallback) failed against Claude Code v2.1.79 because an obfuscated function name (`f$3`) contains `$`, which `\w+` doesn't match
- Changed `\w+` → `[\w$]+` in the Patch 6 regex to cover valid JS identifier characters

## Test plan

- [x] All 6 patches pass against v2.1.79 (`OK`)
- [x] Idempotency verified — second run shows all `SKIP`
- [x] `bash -n` syntax check passes
- [ ] CI check-patches-pr workflow passes