### PR TITLE
feat: universal installer for all Claude Code install types

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,100 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Project
+
+Claude Alias Patch adds custom model aliases to Claude Code by patching its bundled `cli.js`. Users set `ANTHROPIC_DEFAULT_{ALIAS}_MODEL` env vars in `~/.claude/settings.json`, and the patcher injects code to make those aliases available in the Task tool, model picker, and alias resolver.
+
+## Repository Structure
+
+- `scripts/install.sh` — single-file installer. Contains the embedded Python patcher (heredoc) plus the bash installer logic (npm fetch, patching, wrapper install, backup)
+- `scripts/claude-wrapper.sh` — wrapper that replaces the `claude` binary. Handles `claude update` (re-fetch + re-patch) and normal execution (auto re-patch if markers missing, then `exec node cli.js`)
+- `scripts/uninstall.sh` — restores original binary from backup, removes cache
+- `comments-log.md` — log of GitHub comments posted to related issues across repos
+
+## Key Paths at Runtime
+
+- `~/.cache/claude-alias-patch/` — cache dir: `cli.js` (patched), `patch.py` (extracted from install.sh), `.version`
+- `~/.local/bin/claude` — wrapper script (replaces original binary)
+- `~/.local/bin/claude.bak` — backup of original binary (symlink for native, file for npm)
+
+## Installation Architecture
+
+The installer detects the user's existing Claude Code installation type via `detect_claude_install()`:
+
+| Type              | Detection                                                  | What happens                                                                           |
+| ----------------- | ---------------------------------------------------------- | -------------------------------------------------------------------------------------- |
+| `native`          | ELF/Mach-O binary in `~/.local/share/claude/versions/`     | Cannot patch embedded bytecode. Fetches cli.js from npm, patches it, installs wrapper. |
+| `package-manager` | ELF/Mach-O binary elsewhere (brew, apt, etc.)              | Same as native — wrapper approach.                                                     |
+| `npm-global`      | Symlink to `node_modules/@anthropic-ai/claude-code/cli.js` | Wrapper approach (survives `npm update`).                                              |
+| `npm-local`       | Path contains `/.claude/local/`                            | Wrapper approach.                                                                      |
+| `wrapper`         | Already contains `claude-alias-patch` marker               | Upgrade path — re-fetch + re-patch.                                                    |
+| `none`            | `claude` not found in PATH                                 | Fresh install — fetch from npm + wrapper.                                              |
+
+All paths converge on the same approach: fetch cli.js from npm, patch it, run via `exec node cli.js` through the wrapper.
+
+## Patcher Architecture
+
+The patcher (`patch.py`, embedded in `install.sh` lines 50–318) applies 6 patches to Claude Code's `cli.js`:
+
+1. **Zod enum → string** — Task tool accepts any model alias string
+2. **Env var whitelist** — monkey-patches `Set.has()` to accept `ANTHROPIC_DEFAULT_*_MODEL` vars
+3. **Model picker fallback** — appends custom aliases to the catch-all fallback list
+4. **Tool description** — dynamically lists available aliases in the Task tool's describe text
+5. **Model picker UI** — adds custom models to the dropdown with their resolved model ID
+6. **Alias resolver fallback** — regex-based (function names are obfuscated), adds env var lookup after the switch block
+
+Patches 1–5 use literal string matching. Patch 6 uses regex because the target function names change between builds. All patches are idempotent — re-running shows `SKIP` for already-patched locations.
+
+Each patch uses `/*ccpatch:<name>*/` comment markers for idempotency detection.
+
+The `SCAN` constant (line 94–98) is the env var scanner snippet reused across patches 3, 4, and 5 — it extracts alias names from `process.env`.
+
+## Testing Changes
+
+There are no unit tests. Verify patches manually:
+
+```bash
+# Extract patcher from install.sh
+sed -n '/^cat > .*patch\.py.*<< .PATCHER_EOF/,/^PATCHER_EOF/p' scripts/install.sh | tail -n +2 | head -n -1 > /tmp/patch.py
+
+# Fetch latest Claude Code
+npm pack @anthropic-ai/claude-code@latest
+mkdir -p /tmp/test-pkg
+tar -xzf anthropic-ai-claude-code-*.tgz -C /tmp/test-pkg --strip-components=1
+
+# Run patcher — all 6 should show OK (or SKIP if already patched)
+python3 /tmp/patch.py /tmp/test-pkg/cli.js /tmp/test-pkg/cli-patched.js
+
+# Verify idempotency — all 6 should show SKIP
+python3 /tmp/patch.py /tmp/test-pkg/cli-patched.js /tmp/test-pkg/cli-patched2.js
+```
+
+Shell script syntax check: `bash -n scripts/install.sh`
+
+## CI
+
+- `check-patches.yml` — daily cron (08:00 UTC) + manual trigger. Fetches latest Claude Code from npm and runs the patcher. Auto-creates a GitHub issue with `patch-failure` label on failure.
+- `check-patches-pr.yml` — runs on PRs to `main`. Same patcher check.
+
+Both workflows extract `patch.py` from the `install.sh` heredoc at CI time — the patcher is not a standalone file in the repo.
+
+## Working on the Patcher
+
+The patcher is embedded inside `install.sh`. When modifying patches:
+
+1. Edit the Python code inside the `PATCHER_EOF` heredoc in `scripts/install.sh`
+2. The `apply_patch()` function handles: uniqueness check (pattern must appear exactly once), size verification, idempotency via skip markers
+3. For regex-based patches (Patch 6), the manual equivalent of `apply_patch()` is inlined
+4. When Claude Code updates change obfuscated variable names, only the regex patterns need updating — not the replacement logic
+5. Literal patches break when Anthropic changes the matched strings in `cli.js`
+
+## PR Checklist
+
+From the PR template — all must pass before merging:
+
+- All 6 patches pass against the latest Claude Code release
+- Patcher is idempotent (second run shows all SKIP)
+- Shell scripts pass `bash -n` syntax check
+- No external dependencies added

--- a/scripts/claude-wrapper.sh
+++ b/scripts/claude-wrapper.sh
@@ -82,4 +82,10 @@ fi
 # Prevent Claude from auto-migrating to native binary (would overwrite this wrapper)
 export DISABLE_AUTO_MIGRATE_TO_NATIVE=1
 
+# Strip parent session env vars to prevent interference when running
+# claude from within an existing Claude Code session
+unset CLAUDECODE 2>/dev/null || true
+unset CLAUDE_CODE_ENTRYPOINT 2>/dev/null || true
+unset CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS 2>/dev/null || true
+
 exec node "$CLI_JS" "$@"

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -356,26 +356,77 @@ fi
 echo "$VERSION" > "$CACHE_DIR/.version"
 
 # --- Detect existing installation ---
-echo ""
-CLAUDE_PATH=$(which claude 2>/dev/null || echo "")
-if [[ -n "$CLAUDE_PATH" ]]; then
-    if grep -q 'claude-alias-patch' "$CLAUDE_PATH" 2>/dev/null; then
-        echo "  Detected: existing wrapper (updating)"
-    elif [[ -L "$CLAUDE_PATH" ]]; then
-        REAL=$(readlink -f "$CLAUDE_PATH")
-        if file "$REAL" 2>/dev/null | grep -qE 'ELF|Mach-O'; then
-            echo "  Detected: native binary (via symlink → $REAL)"
-            echo "  The binary will be backed up. The patched version runs from npm via node."
-        fi
-    elif file "$CLAUDE_PATH" 2>/dev/null | grep -qE 'ELF|Mach-O'; then
-        echo "  Detected: native binary ($CLAUDE_PATH)"
-        echo "  The binary will be backed up. The patched version runs from npm via node."
-    else
-        echo "  Detected: existing npm installation"
+detect_claude_install() {
+    local claude_path
+    claude_path=$(command -v claude 2>/dev/null) || { echo "none"; return; }
+
+    # Already our wrapper
+    if grep -q 'claude-alias-patch' "$claude_path" 2>/dev/null; then
+        echo "wrapper"; return
     fi
-else
-    echo "  No existing Claude Code installation found"
-fi
+
+    # Resolve symlinks to check the real binary
+    local resolved
+    resolved=$(readlink -f "$claude_path" 2>/dev/null) || resolved="$claude_path"
+
+    # ELF or Mach-O binary
+    if file "$resolved" 2>/dev/null | grep -qE 'ELF|Mach-O'; then
+        if [[ "$resolved" == *"/.local/share/claude/versions/"* ]]; then
+            echo "native"
+        else
+            echo "package-manager"
+        fi
+        return
+    fi
+
+    # npm global — symlink to cli.js
+    if [[ "$resolved" == *"/node_modules/@anthropic-ai/claude-code/cli.js" ]]; then
+        echo "npm-global"; return
+    fi
+
+    # npm local install
+    if [[ "$resolved" == *"/.claude/local/"* ]]; then
+        echo "npm-local"; return
+    fi
+
+    echo "unknown"
+}
+
+echo ""
+INSTALL_TYPE=$(detect_claude_install)
+CLAUDE_PATH=$(command -v claude 2>/dev/null || echo "")
+
+case "$INSTALL_TYPE" in
+    wrapper)
+        echo "  Detected: existing wrapper (upgrading)"
+        ;;
+    native)
+        RESOLVED=$(readlink -f "$CLAUDE_PATH" 2>/dev/null || echo "$CLAUDE_PATH")
+        echo "  Detected: native binary ($RESOLVED)"
+        echo ""
+        echo "  Native binaries embed cli.js — they cannot be patched directly."
+        echo "  The wrapper runs a patched copy from npm via node instead."
+        echo "  Your native binary will be backed up to $BACKUP_PATH"
+        ;;
+    package-manager)
+        RESOLVED=$(readlink -f "$CLAUDE_PATH" 2>/dev/null || echo "$CLAUDE_PATH")
+        echo "  Detected: package-manager binary ($RESOLVED)"
+        echo ""
+        echo "  Package-manager binaries cannot be patched directly."
+        echo "  The wrapper runs a patched copy from npm via node instead."
+        echo "  Your binary will be backed up to $BACKUP_PATH"
+        ;;
+    npm-global|npm-local)
+        echo "  Detected: npm installation ($CLAUDE_PATH)"
+        ;;
+    none)
+        echo "  No existing Claude Code installation found"
+        ;;
+    unknown)
+        echo "  Detected: unknown installation type ($CLAUDE_PATH)"
+        echo "  The wrapper will be installed alongside it."
+        ;;
+esac
 
 # --- Install wrapper ---
 echo ""

--- a/scripts/uninstall.sh
+++ b/scripts/uninstall.sh
@@ -14,11 +14,35 @@ echo ""
 
 # Restore backup
 if [[ -e "$BACKUP_PATH" ]]; then
-    rm -f "$BIN_PATH" 2>/dev/null || true
-    mv "$BACKUP_PATH" "$BIN_PATH"
-    if [[ -L "$BIN_PATH" ]]; then
-        echo "  Restored original symlink: $BIN_PATH → $(readlink -f "$BIN_PATH")"
+    # Check if backup symlink target still exists (native binary may have self-updated)
+    if [[ -L "$BACKUP_PATH" ]]; then
+        BACKUP_TARGET=$(readlink "$BACKUP_PATH")
+        if [[ ! -e "$BACKUP_TARGET" ]]; then
+            echo "  Backup target no longer exists: $BACKUP_TARGET"
+            # Native binary auto-updated and cleaned up old version — find latest
+            LATEST=$(ls -t "$HOME/.local/share/claude/versions/" 2>/dev/null | head -1)
+            if [[ -n "$LATEST" ]]; then
+                rm -f "$BIN_PATH" "$BACKUP_PATH" 2>/dev/null || true
+                ln -s "$HOME/.local/share/claude/versions/$LATEST" "$BIN_PATH"
+                echo "  Restored to latest native version: $LATEST"
+            else
+                rm -f "$BIN_PATH" "$BACKUP_PATH" 2>/dev/null || true
+                echo "  Removed wrapper. No native binary found."
+                echo "  Reinstall Claude Code: https://docs.anthropic.com/en/docs/claude-code/getting-started"
+            fi
+        else
+            rm -f "$BIN_PATH" 2>/dev/null || true
+            mv "$BACKUP_PATH" "$BIN_PATH"
+            if [[ -L "$BIN_PATH" ]]; then
+                echo "  Restored original symlink: $BIN_PATH → $(readlink -f "$BIN_PATH")"
+            else
+                echo "  Restored original: $BIN_PATH"
+            fi
+        fi
     else
+        # Backup is a regular file — simple restore
+        rm -f "$BIN_PATH" 2>/dev/null || true
+        mv "$BACKUP_PATH" "$BIN_PATH"
         echo "  Restored original: $BIN_PATH"
     fi
 elif [[ -e "$BIN_PATH" ]] && grep -q 'claude-alias-patch' "$BIN_PATH" 2>/dev/null; then


### PR DESCRIPTION
## Summary

- Adds `detect_claude_install()` function that properly identifies: `native`, `npm-global`, `npm-local`, `package-manager`, `wrapper`, and `none` installation types
- Shows clear per-type messaging explaining why the wrapper is needed (native binaries embed cli.js in Bun bytecode — cannot be patched directly)
- Strips `CLAUDECODE` and related env vars in wrapper to prevent hangs when running from within an existing Claude Code session
- Handles stale backup symlinks in uninstaller — when the native binary self-updates and cleans old versions, the uninstaller finds the latest available version instead of restoring a dead symlink
- Updates CLAUDE.md with installation architecture documentation

## Context

Users with native Claude Code binaries (installed via `claude` auto-updater) ran the installer, which replaced their binary with a bash wrapper running `exec node cli.js`. This caused:
1. Confusing behavior — no warning that the native binary would be shadowed
2. Stale backups — native binary auto-updated from 2.1.58→2.1.62 but backup still pointed to 2.1.58
3. Uninstaller restored a dead symlink

## Test plan

- [ ] All 6 patches pass against the latest Claude Code release
- [ ] Patcher is idempotent (second run shows all SKIP)
- [ ] Shell scripts pass `bash -n` syntax check
- [ ] Detection correctly identifies native binary on a system with native Claude
- [ ] Detection correctly identifies npm-global on a system with npm-installed Claude
- [ ] Uninstaller handles stale backup symlinks (backup points to deleted version)
- [ ] Wrapper works from within an existing Claude Code session (env vars stripped)